### PR TITLE
버튼 컴포넌트 props 오타 수정

### DIFF
--- a/components/common/Button/index.tsx
+++ b/components/common/Button/index.tsx
@@ -13,7 +13,7 @@ export default function Button(props: ButtonType) {
       borderRadius={props.borderRadius}
       fontWeight={props.fontWeight}
       hoverBackground={props.hoverBackground}
-      hoverBorder={props.hoverBackground}
+      hoverBorder={props.hoverBorder}
       hoverColor={props.hoverColor}
       onClick={props.onClick}
     >


### PR DESCRIPTION
## 💡 개요
styled-components 에 주고있떤 props를 똑같은 이름으로 주고 있던게 있었습니다.
## 📃 작업내용
props의 이름을 변경했습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
