### PR TITLE
🔀 공지 목록 불러오기, 삭제 기능 추가

### DIFF
--- a/components/NoticePage/NoticeItem/index.tsx
+++ b/components/NoticePage/NoticeItem/index.tsx
@@ -1,22 +1,21 @@
 import Link from 'next/link'
 import * as S from './style'
 import { NoticeItemType } from '@/types/NoticeItemType'
+import { dateToString } from '@/utils/formatter'
 
 export default function NoticeItem({
   noticeId,
   title,
-  date,
+  createdAt,
   user,
 }: NoticeItemType) {
   return (
     <Link href='/notice/detail'>
       <S.NoticeItemContainer>
-        <S.NoticeIdContainer>
-          <S.NoticeID>{noticeId}</S.NoticeID>
-        </S.NoticeIdContainer>
+        <S.NoticeIdContainer></S.NoticeIdContainer>
         <S.NoticeTitle>{title}</S.NoticeTitle>
-        <S.NoticeDate>{date}</S.NoticeDate>
-        <S.NoticeUser>{user}</S.NoticeUser>
+        <S.NoticeDate>{dateToString(createdAt)}</S.NoticeDate>
+        <S.NoticeUser>{user.name}</S.NoticeUser>
       </S.NoticeItemContainer>
     </Link>
   )

--- a/components/NoticePage/NoticeItem/index.tsx
+++ b/components/NoticePage/NoticeItem/index.tsx
@@ -3,13 +3,22 @@ import * as S from './style'
 import { NoticeItemType } from '@/types/NoticeItemType'
 import { dateToString } from '@/utils/formatter'
 import * as SVG from '@/assets/svg'
+import useFetch from '@/hooks/useFetch'
 
 export default function NoticeItem({
   noticeId,
   title,
   createdAt,
   user,
+  noticeList,
 }: NoticeItemType) {
+  const { fetch } = useFetch({ url: `/notice/${noticeId}`, method: 'delete' })
+
+  const onDelete = (e: React.MouseEvent) => {
+    e.preventDefault()
+    fetch()
+    noticeList()
+  }
   return (
     <Link href='/notice/detail'>
       <S.NoticeItemContainer>
@@ -17,7 +26,7 @@ export default function NoticeItem({
         <S.NoticeTitle>{title}</S.NoticeTitle>
         <S.NoticeDate>{dateToString(createdAt)}</S.NoticeDate>
         <S.NoticeUser>{user.name}</S.NoticeUser>
-        <S.SVG>
+        <S.SVG onClick={onDelete}>
           <SVG.XMark />
         </S.SVG>
       </S.NoticeItemContainer>

--- a/components/NoticePage/NoticeItem/index.tsx
+++ b/components/NoticePage/NoticeItem/index.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import * as S from './style'
 import { NoticeItemType } from '@/types/NoticeItemType'
 import { dateToString } from '@/utils/formatter'
+import * as SVG from '@/assets/svg'
 
 export default function NoticeItem({
   noticeId,
@@ -16,6 +17,9 @@ export default function NoticeItem({
         <S.NoticeTitle>{title}</S.NoticeTitle>
         <S.NoticeDate>{dateToString(createdAt)}</S.NoticeDate>
         <S.NoticeUser>{user.name}</S.NoticeUser>
+        <S.SVG>
+          <SVG.XMark />
+        </S.SVG>
       </S.NoticeItemContainer>
     </Link>
   )

--- a/components/NoticePage/NoticeItem/style.ts
+++ b/components/NoticePage/NoticeItem/style.ts
@@ -31,7 +31,7 @@ export const NoticeIdContainer = styled.div`
 `
 
 export const NoticeTitle = styled.div`
-  width: 69%;
+  width: 60%;
   padding-right: 20px;
   overflow: hidden;
   white-space: nowrap;
@@ -42,9 +42,16 @@ export const NoticeTitle = styled.div`
 export const NoticeDate = styled.div`
   width: 12%;
   color: #b1b1b1;
+  text-align: center;
 `
 
 export const NoticeUser = styled.div`
   width: 12%;
   color: #b1b1b1;
+  text-align: center;
+`
+
+export const SVG = styled.div`
+  width: 9%;
+  text-align: center;
 `

--- a/components/NoticePage/NoticeItem/style.ts
+++ b/components/NoticePage/NoticeItem/style.ts
@@ -8,6 +8,7 @@ export const NoticeItemContainer = styled.div`
   background-color: #fff;
   border-radius: 8px;
   cursor: pointer;
+  position: relative;
 
   &:hover {
     background-color: #f5f9ff;
@@ -52,6 +53,8 @@ export const NoticeUser = styled.div`
 `
 
 export const SVG = styled.div`
-  width: 9%;
+  position: absolute;
   text-align: center;
+  right: 24px;
+  padding: 8px;
 `

--- a/components/NoticePage/NoticeItemList/index.tsx
+++ b/components/NoticePage/NoticeItemList/index.tsx
@@ -1,143 +1,29 @@
 import * as S from './style'
 import NoticeItem from '../NoticeItem'
+import useFetch from '@/hooks/useFetch'
+import { useEffect } from 'react'
+import { NoticeItemType } from '@/types/NoticeItemType'
 
 export default function NoticeItemList() {
-  const test = [
-    {
-      noticeId: 1,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염 ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 2,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염염염염소 소나무 무지개',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 3,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염엄엄엄어~',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 4,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 11,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 999,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 4,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 11,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 999,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 4,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 11,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 999,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 4,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 11,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 999,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 4,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 11,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-    {
-      noticeId: 999,
-      title:
-        '이번주 10/21~20/25까지는 학부모상담주간으로 인해 홈베이스 사용을 금지합니다. 금지금지 수고하세염',
-      date: '2023.12.17',
-      user: '서주미',
-    },
-  ]
+  const { fetch, data } = useFetch<NoticeItemType[]>({
+    url: '/notice',
+    method: 'get',
+  })
+
+  useEffect(() => {
+    fetch()
+  }, [])
+
+  if (!data) return <div />
+
   return (
     <S.NoticeItemListContainer>
-      {test.map(({ noticeId, title, date, user }, index) => (
+      {data.map(({ noticeId, title, createdAt, user }, index) => (
         <NoticeItem
           key={index}
           noticeId={noticeId}
           title={title}
-          date={date}
+          createdAt={createdAt}
           user={user}
         />
       ))}

--- a/components/NoticePage/NoticeItemList/index.tsx
+++ b/components/NoticePage/NoticeItemList/index.tsx
@@ -2,10 +2,10 @@ import * as S from './style'
 import NoticeItem from '../NoticeItem'
 import useFetch from '@/hooks/useFetch'
 import { useEffect } from 'react'
-import { NoticeItemType } from '@/types/NoticeItemType'
+import { NoticeItemListType } from '@/types/NoticeItemListType'
 
 export default function NoticeItemList() {
-  const { fetch, data } = useFetch<NoticeItemType[]>({
+  const { fetch, data } = useFetch<NoticeItemListType[]>({
     url: '/notice',
     method: 'get',
   })
@@ -25,6 +25,7 @@ export default function NoticeItemList() {
           title={title}
           createdAt={createdAt}
           user={user}
+          noticeList={fetch}
         />
       ))}
     </S.NoticeItemListContainer>

--- a/types/NoticeItemListType.ts
+++ b/types/NoticeItemListType.ts
@@ -1,4 +1,4 @@
-export interface NoticeItemType {
+export interface NoticeItemListType {
   noticeNum?: number
   noticeId: string
   title: string
@@ -10,5 +10,4 @@ export interface NoticeItemType {
     classNum: number
     number: number
   }
-  noticeList: (body?: any) => Promise<void>
 }

--- a/types/NoticeItemType.ts
+++ b/types/NoticeItemType.ts
@@ -1,6 +1,13 @@
 export interface NoticeItemType {
-  noticeId: number
+  noticeNum?: number
+  noticeId: string
   title: string
-  date: string
-  user: string
+  createdAt: string
+  user: {
+    userId: string
+    name: string
+    grade: number
+    classNum: number
+    number: number
+  }
 }

--- a/utils/formatter.ts
+++ b/utils/formatter.ts
@@ -1,0 +1,6 @@
+export const dateToString = (date: string, separator = '.') => {
+  const yyyy = date.substring(0, 4)
+  const MM = date.substring(5, 7)
+  const dd = date.substring(8, 10)
+  return `${yyyy}${separator}${MM}${separator}${dd}`
+}


### PR DESCRIPTION
## 💡 개요
작성된 공지 목록을 불러오고 글 삭제 기능이 필요함
## 📃 작업내용
- 작성된 공지 글들을 목록에 불러왔습니다.
- 공지 글 개별 삭제를 위해 item에 x mark svg를 추가했습니다.
- 공지 글 삭제 기능을 구현했습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
