### PR TITLE
🔀 학생 예약 상태 변경 모달 추가 퍼블리싱 및 기능 구현

### DIFF
--- a/atoms/atom.ts
+++ b/atoms/atom.ts
@@ -28,14 +28,16 @@ export const UserList = atom<UserItemType[]>({
   key: 'UserList',
   default: [],
 })
-export const SelectUser = atom<{
-  classNum: number
-  email: string
-  grade: number
-  number: number
-  name: string
-  profileImageUrl: string
+export const SelectedUser = atom<{
   userId: string
+  email: string
+  name: string
+  grade: number
+  classNum: number
+  number: number
+  profileImageUrl: string
+  roles: string[]
+  useStatus: 'AVAILABLE' | 'UNAVAILABLE'
 }>({
   key: 'SelectUser',
   default: {
@@ -46,9 +48,7 @@ export const SelectUser = atom<{
     number: 1,
     profileImageUrl: '',
     userId: '',
+    useStatus: 'AVAILABLE',
+    roles: [],
   },
-})
-export const SelectUserState = atom<string>({
-  key: 'SelectuserState',
-  default: '',
 })

--- a/atoms/atom.ts
+++ b/atoms/atom.ts
@@ -1,3 +1,4 @@
+import { UserItemType } from '@/types/UserItemType'
 import { UserListType } from '@/types/components/UserListType'
 import { getStorage } from '@/utils/Storage'
 import { atom } from 'recoil'
@@ -18,4 +19,36 @@ export const ReasonText = atom<string>({ key: 'ReasonText', default: '' })
 export const Place = atom<{ floor: string; period: string }>({
   key: 'Place',
   default: { floor: '', period: '' },
+})
+export const IsStuStateModal = atom<boolean>({
+  key: 'IsStuStateModal',
+  default: false,
+})
+export const UserList = atom<UserItemType[]>({
+  key: 'UserList',
+  default: [],
+})
+export const SelectUser = atom<{
+  classNum: number
+  email: string
+  grade: number
+  number: number
+  name: string
+  profileImageUrl: string
+  userId: string
+}>({
+  key: 'SelectUser',
+  default: {
+    classNum: 1,
+    email: '',
+    grade: 1,
+    name: '',
+    number: 1,
+    profileImageUrl: '',
+    userId: '',
+  },
+})
+export const SelectUserState = atom<string>({
+  key: 'SelectuserState',
+  default: '',
 })

--- a/atoms/atom.ts
+++ b/atoms/atom.ts
@@ -1,5 +1,4 @@
 import { UserItemType } from '@/types/UserItemType'
-import { UserListType } from '@/types/components/UserListType'
 import { getStorage } from '@/utils/Storage'
 import { atom } from 'recoil'
 
@@ -10,7 +9,7 @@ export const HasLogin = atom<boolean>({
   key: 'HasLogin',
   default: getStorage('hi_accessToken') ? true : false,
 })
-export const ShowMembers = atom<UserListType[]>({
+export const ShowMembers = atom<>({
   key: 'ShowMembers',
   default: [],
 })
@@ -28,17 +27,7 @@ export const UserList = atom<UserItemType[]>({
   key: 'UserList',
   default: [],
 })
-export const SelectedUser = atom<{
-  userId: string
-  email: string
-  name: string
-  grade: number
-  classNum: number
-  number: number
-  profileImageUrl: string
-  roles: string[]
-  useStatus: 'AVAILABLE' | 'UNAVAILABLE'
-}>({
+export const SelectedUser = atom<UserItemType>({
   key: 'SelectUser',
   default: {
     classNum: 1,

--- a/components/UserPage/StuState/index.tsx
+++ b/components/UserPage/StuState/index.tsx
@@ -1,25 +1,19 @@
 import Portal from '@/components/Portal'
 import * as S from './style'
-import {
-  IsStuStateModal,
-  SelectUser,
-  SelectUserState,
-  UserList,
-} from '@/atoms/atom'
+import { IsStuStateModal, SelectedUser } from '@/atoms/atom'
 import { useRecoilValue, useSetRecoilState } from 'recoil'
 import Button from '@/components/common/Button'
 import useFetch from '@/hooks/useFetch'
 
 export default function StuState({ userlistRefetch }: any) {
   const setIsStuStateModal = useSetRecoilState<boolean>(IsStuStateModal)
-  const selectUser = useRecoilValue(SelectUser)
-  const selectUserState = useRecoilValue(SelectUserState)
+  const selectedUser = useRecoilValue(SelectedUser)
   const onClose = () => {
     setIsStuStateModal(false)
   }
 
   const { fetch } = useFetch({
-    url: `/user/${selectUser.userId}`,
+    url: `/user/${selectedUser.userId}`,
     method: 'patch',
     onSuccess: () => onClose(),
     successMessage: '예약 상태가 변경되었습니다.',
@@ -30,7 +24,8 @@ export default function StuState({ userlistRefetch }: any) {
 
   const chageStudentState = async () => {
     await fetch({
-      status: selectUserState === 'AVAILABLE' ? 'UNAVAILABLE' : 'AVAILABLE',
+      status:
+        selectedUser.useStatus === 'AVAILABLE' ? 'UNAVAILABLE' : 'AVAILABLE',
     })
     await userlistRefetch()
   }
@@ -38,15 +33,17 @@ export default function StuState({ userlistRefetch }: any) {
     <Portal onClose={onClose}>
       <S.ModalConatiner>
         <p>
-          {selectUser.grade}
-          {selectUser.classNum}
-          {selectUser.number.toString().length === 2
-            ? selectUser.number
-            : '0' + selectUser.number}{' '}
-          {selectUser.name}
-          님을 {selectUserState === 'AVAILABLE' ? '예약불가' : '예약가능'}
-          <br />
-          시키시겠습니까?
+          {selectedUser.grade}
+          {selectedUser.classNum}
+          {selectedUser.number.toString().length === 2
+            ? selectedUser.number
+            : '0' + selectedUser.number}{' '}
+          {selectedUser.name}
+          님을{' '}
+          {selectedUser.useStatus === 'AVAILABLE'
+            ? '예약불가 상태'
+            : '예약가능 상태'}
+          <br />로 변경하시겠습니까?
         </p>
         <S.ButtonWrapper>
           <Button

--- a/components/UserPage/StuState/index.tsx
+++ b/components/UserPage/StuState/index.tsx
@@ -43,7 +43,8 @@ export default function StuState({ userlistRefetch }: any) {
           {selectedUser.useStatus === 'AVAILABLE'
             ? '예약불가 상태'
             : '예약가능 상태'}
-          <br />로 변경하시겠습니까?
+          로<br />
+          변경하시겠습니까?
         </p>
         <S.ButtonWrapper>
           <Button

--- a/components/UserPage/StuState/index.tsx
+++ b/components/UserPage/StuState/index.tsx
@@ -1,0 +1,78 @@
+import Portal from '@/components/Portal'
+import * as S from './style'
+import {
+  IsStuStateModal,
+  SelectUser,
+  SelectUserState,
+  UserList,
+} from '@/atoms/atom'
+import { useRecoilValue, useSetRecoilState } from 'recoil'
+import Button from '@/components/common/Button'
+import useFetch from '@/hooks/useFetch'
+
+export default function StuState({ userlistRefetch }: any) {
+  const setIsStuStateModal = useSetRecoilState<boolean>(IsStuStateModal)
+  const selectUser = useRecoilValue(SelectUser)
+  const selectUserState = useRecoilValue(SelectUserState)
+  const onClose = () => {
+    setIsStuStateModal(false)
+  }
+
+  const { fetch } = useFetch({
+    url: `/user/${selectUser.userId}`,
+    method: 'patch',
+    onSuccess: () => onClose(),
+    successMessage: '예약 상태가 변경되었습니다.',
+    errorMessage: {
+      401: '토큰 값이 이상하거나 변질되었습니다.',
+    },
+  })
+
+  const chageStudentState = async () => {
+    await fetch({
+      status: selectUserState === 'AVAILABLE' ? 'UNAVAILABLE' : 'AVAILABLE',
+    })
+    await userlistRefetch()
+  }
+  return (
+    <Portal onClose={onClose}>
+      <S.ModalConatiner>
+        <p>
+          {selectUser.grade}
+          {selectUser.classNum}
+          {selectUser.number.toString().length === 2
+            ? selectUser.number
+            : '0' + selectUser.number}{' '}
+          {selectUser.name}
+          님을 {selectUserState === 'AVAILABLE' ? '예약불가' : '예약가능'}
+          <br />
+          시키시겠습니까?
+        </p>
+        <S.ButtonWrapper>
+          <Button
+            width='120px'
+            height='44px'
+            background='#fff'
+            border='1px solid #0066FF'
+            borderRadius='8px'
+            color='#0066FF'
+            onClick={onClose}
+          >
+            취소
+          </Button>
+          <Button
+            width='120px'
+            height='44px'
+            background='#0066FF'
+            border='1px solid #0066FF'
+            borderRadius='8px'
+            color='#fff'
+            onClick={chageStudentState}
+          >
+            확인
+          </Button>
+        </S.ButtonWrapper>
+      </S.ModalConatiner>
+    </Portal>
+  )
+}

--- a/components/UserPage/StuState/style.ts
+++ b/components/UserPage/StuState/style.ts
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled'
+
+export const ModalConatiner = styled.div`
+  width: 300px;
+  height: 200px;
+  background: #fff;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+  padding-top: 48px;
+
+  p {
+    text-align: center;
+    line-height: 28px;
+  }
+`
+export const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 12px;
+`

--- a/components/UserPage/UserItem/index.tsx
+++ b/components/UserPage/UserItem/index.tsx
@@ -4,26 +4,32 @@ import * as SVG from '@/assets/svg'
 import { UserItemType } from '@/types/UserItemType'
 import Image from 'next/image'
 import { useRecoilState, useSetRecoilState } from 'recoil'
-import { IsStuStateModal, SelectUser, SelectUserState } from '@/atoms/atom'
+import { IsStuStateModal, SelectedUser } from '@/atoms/atom'
 import StuState from '../StuState'
 
 export default function UserItem({
-  user,
+  userId,
+  email,
+  name,
+  grade,
+  classNum,
+  number,
+  profileImageUrl,
+  roles,
   useStatus,
   userlistRefetch,
 }: UserItemType) {
   const buttonColor = useStatus === 'AVAILABLE' ? '#00A441' : '#C0C0C0'
   const [isStuStateModal, setIsStuStateModal] =
     useRecoilState<boolean>(IsStuStateModal)
-  const setSelectUser = useSetRecoilState(SelectUser)
-  const setSelectUserState = useSetRecoilState(SelectUserState)
+  const setSelectedUser = useSetRecoilState(SelectedUser)
 
   return (
     <S.UserItemContainer>
       <S.UserItemWrraper>
-        {user.profileImageUrl ? (
+        {profileImageUrl ? (
           <Image
-            src={user.profileImageUrl}
+            src={profileImageUrl}
             alt='profileImage'
             width='48'
             height='48'
@@ -33,14 +39,11 @@ export default function UserItem({
         )}
         <S.UserInfo>
           <S.UserName>
-            {user.grade}
-            {user.classNum}
-            {user.number.toString().length === 2
-              ? user.number
-              : '0' + user.number}{' '}
-            {user.name}
+            {grade}
+            {classNum}
+            {number.toString().length === 2 ? number : '0' + number} {name}
           </S.UserName>
-          <S.UserEmail>{user.email}</S.UserEmail>
+          <S.UserEmail>{email}</S.UserEmail>
         </S.UserInfo>
       </S.UserItemWrraper>
       <Button
@@ -53,8 +56,17 @@ export default function UserItem({
         color={buttonColor}
         onClick={() => {
           setIsStuStateModal(true)
-          setSelectUser(user)
-          setSelectUserState(useStatus)
+          setSelectedUser({
+            userId,
+            email,
+            name,
+            grade,
+            classNum,
+            number,
+            profileImageUrl,
+            useStatus,
+            roles,
+          })
         }}
       >
         {useStatus === 'AVAILABLE' ? '예약가능' : '예약불가'}

--- a/components/UserPage/UserItem/index.tsx
+++ b/components/UserPage/UserItem/index.tsx
@@ -3,7 +3,9 @@ import * as S from './style'
 import * as SVG from '@/assets/svg'
 import { UserItemType } from '@/types/UserItemType'
 import Image from 'next/image'
-import useFetch from '@/hooks/useFetch'
+import { useRecoilState, useSetRecoilState } from 'recoil'
+import { IsStuStateModal, SelectUser, SelectUserState } from '@/atoms/atom'
+import StuState from '../StuState'
 
 export default function UserItem({
   user,
@@ -11,18 +13,10 @@ export default function UserItem({
   userlistRefetch,
 }: UserItemType) {
   const buttonColor = useStatus === 'AVAILABLE' ? '#00A441' : '#C0C0C0'
-
-  const { fetch } = useFetch({
-    url: `/user/${user.userId}`,
-    method: 'patch',
-  })
-
-  const chageStudentState = async () => {
-    await fetch({
-      status: useStatus === 'AVAILABLE' ? 'UNAVAILABLE' : 'AVAILABLE',
-    })
-    await userlistRefetch()
-  }
+  const [isStuStateModal, setIsStuStateModal] =
+    useRecoilState<boolean>(IsStuStateModal)
+  const setSelectUser = useSetRecoilState(SelectUser)
+  const setSelectUserState = useSetRecoilState(SelectUserState)
 
   return (
     <S.UserItemContainer>
@@ -57,10 +51,15 @@ export default function UserItem({
         background='none'
         fontWeight='600'
         color={buttonColor}
-        onClick={chageStudentState}
+        onClick={() => {
+          setIsStuStateModal(true)
+          setSelectUser(user)
+          setSelectUserState(useStatus)
+        }}
       >
         {useStatus === 'AVAILABLE' ? '예약가능' : '예약불가'}
       </Button>
+      {isStuStateModal && <StuState userlistRefetch={userlistRefetch} />}
     </S.UserItemContainer>
   )
 }

--- a/components/UserPage/UserItemList/index.tsx
+++ b/components/UserPage/UserItemList/index.tsx
@@ -24,14 +24,36 @@ export default function UserItemList() {
 
   return (
     <S.UserItemListContainer>
-      {userList.map(({ useStatus, user }, idx) => (
-        <UserItem
-          key={idx}
-          user={user}
-          useStatus={useStatus}
-          userlistRefetch={fetch}
-        />
-      ))}
+      {userList.map(
+        (
+          {
+            userId,
+            email,
+            name,
+            grade,
+            classNum,
+            number,
+            profileImageUrl,
+            roles,
+            useStatus,
+          },
+          idx
+        ) => (
+          <UserItem
+            key={idx}
+            userlistRefetch={fetch}
+            userId={userId}
+            email={email}
+            name={name}
+            grade={grade}
+            classNum={classNum}
+            number={number}
+            profileImageUrl={profileImageUrl}
+            roles={roles}
+            useStatus={useStatus}
+          />
+        )
+      )}
     </S.UserItemListContainer>
   )
 }

--- a/components/UserPage/UserItemList/index.tsx
+++ b/components/UserPage/UserItemList/index.tsx
@@ -3,11 +3,17 @@ import * as S from './style'
 import UserItem from '../UserItem'
 import useFetch from '@/hooks/useFetch'
 import { UserItemListType } from '@/types/UserItemListType'
+import { useRecoilState } from 'recoil'
+import { UserList } from '@/atoms/atom'
 
 export default function UserItemList() {
+  const [userList, setUserList] = useRecoilState(UserList)
   const { fetch, data } = useFetch<UserItemListType>({
     url: '/user/students',
     method: 'get',
+    onSuccess: (data) => {
+      setUserList(data.student)
+    },
   })
 
   useEffect(() => {
@@ -18,7 +24,7 @@ export default function UserItemList() {
 
   return (
     <S.UserItemListContainer>
-      {data.student.map(({ useStatus, user, userlistRefetch }, idx) => (
+      {userList.map(({ useStatus, user }, idx) => (
         <UserItem
           key={idx}
           user={user}

--- a/types/UserItemListType.ts
+++ b/types/UserItemListType.ts
@@ -1,5 +1,3 @@
 import { UserItemType } from './UserItemType'
 
-export interface UserItemListType {
-  student: UserItemType[]
-}
+export type UserItemListType = { student: UserItemType[] }

--- a/types/UserItemType.ts
+++ b/types/UserItemType.ts
@@ -1,13 +1,12 @@
 export interface UserItemType {
-  useStatus: string
-  user: {
-    userId: string
-    email: string
-    name: string
-    grade: number
-    classNum: number
-    number: number
-    profileImageUrl: string
-  }
+  userId: string
+  email: string
+  name: string
+  grade: number
+  classNum: number
+  number: number
+  profileImageUrl: string
+  roles: []
+  useStatus: 'AVAILABLE' | 'UNAVAILABLE'
   userlistRefetch: (body?: any) => Promise<void>
 }

--- a/types/UserItemType.ts
+++ b/types/UserItemType.ts
@@ -8,5 +8,5 @@ export interface UserItemType {
   profileImageUrl: string
   roles: []
   useStatus: 'AVAILABLE' | 'UNAVAILABLE'
-  userlistRefetch: (body?: any) => Promise<void>
+  userlistRefetch?: (body?: any) => Promise<void>
 }

--- a/types/components/UserListType.ts
+++ b/types/components/UserListType.ts
@@ -1,7 +1,0 @@
-export interface UserListType {
-  userId: string
-  name: string
-  grade: number
-  classNum: number
-  number: number
-}


### PR DESCRIPTION
## 💡 개요
예약 상태 변경 모달 디자인 추가
## 📃 작업내용
- 예약 상태 변경 버튼을 클릭시 모달 추가
- 전체 학생 data를 전역 상태인 UserList에 추가
- 모달에 선택한 학생의 정보를 넘기는 과정에서 전역 상태 setSelectedUser 추가
- user type 변경
<img width="1670" alt="image" src="https://github.com/GSM-MSG/Hi-v2-FrontEnd/assets/103751430/effa6ef0-75b9-4574-898c-dbe9e2701809">
<img width="1412" alt="image" src="https://github.com/GSM-MSG/Hi-v2-FrontEnd/assets/103751430/1fba3938-5895-4661-938c-7eb41cc89b49">

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
