### PR TITLE
🔀 Button, Input 컴포넌트 Props 타입 상속

### DIFF
--- a/components/Common/Input/index.tsx
+++ b/components/Common/Input/index.tsx
@@ -11,13 +11,7 @@ const Input = (props: InputPropsType, ref: any) => {
       border={props.border}
       padding={props.padding}
       borderRadius={props.borderRadius}
-      placeholder={props.placeholder}
-      onChange={props.onChange}
-      value={props.value}
-      name={props.name}
       focus={props.focus}
-      autoComplete={props.autoComplete}
-      disabled={props.disabled}
     />
   )
 }

--- a/components/common/Button/index.tsx
+++ b/components/common/Button/index.tsx
@@ -15,8 +15,6 @@ export default function Button(props: ButtonPropsType) {
       hoverBackground={props.hoverBackground}
       hoverBorder={props.hoverBorder}
       hoverColor={props.hoverColor}
-      onClick={props.onClick}
-      disabled={props.disabled}
     >
       {props.children}
     </S.Button>

--- a/modals/ReservationModal/Page/MemberSelect/index.tsx
+++ b/modals/ReservationModal/Page/MemberSelect/index.tsx
@@ -103,7 +103,7 @@ function MemberSelect() {
           height='2rem'
           font-size='1rem'
           border='none'
-          autoComplete='off'
+          autoComplete='no'
           {...register('member')}
         />
         {watch('member').length > 0 && (

--- a/types/components/ButtonPropsType.ts
+++ b/types/components/ButtonPropsType.ts
@@ -1,4 +1,7 @@
-export interface ButtonPropsType {
+import { ButtonHTMLAttributes } from 'react'
+
+export interface ButtonPropsType
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode
   width?: string
   height?: string
@@ -11,6 +14,4 @@ export interface ButtonPropsType {
   hoverBackground?: string
   hoverBorder?: string
   hoverColor?: string
-  onClick?: React.MouseEventHandler<HTMLButtonElement>
-  disabled?: boolean
 }

--- a/types/components/InputPropsType.ts
+++ b/types/components/InputPropsType.ts
@@ -1,15 +1,11 @@
-export interface InputPropsType {
+import { InputHTMLAttributes } from 'react'
+
+export interface InputPropsType extends InputHTMLAttributes<HTMLInputElement> {
   width?: string
   height?: string
   border?: string
   padding?: string
   color?: string
   borderRadius?: string
-  placeholder?: string
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
-  value?: string
-  name?: string
   focus?: boolean
-  autoComplete?: string
-  disabled?: boolean
 }


### PR DESCRIPTION
## 💡 개요
onClick이나 disabled, placeholder와 같은 기본 속성들을 props로 넘겨주는 방식이었습니다.
## 📃 작업내용
본래 HTML 태그의 타입을 상속받아 기본 속성들을 넘겨주지 않아도 되게 수정했습니다. 
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
