### PR TITLE
🔀 common에 나머지 매개변수 추가

### DIFF
--- a/components/Common/Input/index.tsx
+++ b/components/Common/Input/index.tsx
@@ -1,8 +1,8 @@
 import { InputPropsType } from '@/types/components/InputPropsType'
 import * as S from './style'
-import React, { forwardRef } from 'react'
+import React, { forwardRef, memo } from 'react'
 
-const Input = (
+function Input(
   {
     width,
     height,
@@ -13,7 +13,7 @@ const Input = (
     ...rest
   }: InputPropsType,
   ref: any
-) => {
+) {
   return (
     <S.Input
       ref={ref}
@@ -28,4 +28,4 @@ const Input = (
   )
 }
 
-export default forwardRef(Input)
+export default memo(forwardRef(Input))

--- a/components/Common/Input/index.tsx
+++ b/components/Common/Input/index.tsx
@@ -2,16 +2,28 @@ import { InputPropsType } from '@/types/components/InputPropsType'
 import * as S from './style'
 import React, { forwardRef } from 'react'
 
-const Input = (props: InputPropsType, ref: any) => {
+const Input = (
+  {
+    width,
+    height,
+    border,
+    padding,
+    borderRadius,
+    focus,
+    ...rest
+  }: InputPropsType,
+  ref: any
+) => {
   return (
     <S.Input
       ref={ref}
-      width={props.width}
-      height={props.height}
-      border={props.border}
-      padding={props.padding}
-      borderRadius={props.borderRadius}
-      focus={props.focus}
+      width={width}
+      height={height}
+      border={border}
+      padding={padding}
+      borderRadius={borderRadius}
+      focus={focus}
+      {...rest}
     />
   )
 }

--- a/components/Common/Textarea/index.tsx
+++ b/components/Common/Textarea/index.tsx
@@ -1,17 +1,20 @@
 import * as S from './style'
 import { TextareaPropsType } from '@/types/components/TextAreaProps'
 
-export default function Textarea(props: TextareaPropsType) {
+export default function Textarea({
+  height,
+  borderColor,
+  fontSize,
+  margin,
+  ...rest
+}: TextareaPropsType) {
   return (
     <S.Textarea
-      value={props.value}
-      height={props.height}
-      borderColor={props.borderColor}
-      placeholder={props.placeholder}
-      fontSize={props.fontSize}
-      margin={props.margin}
-      onChange={props.onChange}
-      name={props.name}
+      height={height}
+      borderColor={borderColor}
+      fontSize={fontSize}
+      margin={margin}
+      {...rest}
     />
   )
 }

--- a/components/Common/Textarea/index.tsx
+++ b/components/Common/Textarea/index.tsx
@@ -1,7 +1,8 @@
 import * as S from './style'
 import { TextareaPropsType } from '@/types/components/TextAreaProps'
+import { memo } from 'react'
 
-export default function Textarea({
+function Textarea({
   height,
   borderColor,
   fontSize,
@@ -18,3 +19,5 @@ export default function Textarea({
     />
   )
 }
+
+export default memo(Textarea)

--- a/components/common/Button/index.tsx
+++ b/components/common/Button/index.tsx
@@ -1,22 +1,37 @@
 import { ButtonPropsType } from '@/types/components/ButtonPropsType'
 import * as S from './style'
 
-export default function Button(props: ButtonPropsType) {
+export default function Button({
+  children,
+  width,
+  height,
+  fontSize,
+  color,
+  background,
+  border,
+  borderRadius,
+  fontWeight,
+  hoverBackground,
+  hoverBorder,
+  hoverColor,
+  ...rest
+}: ButtonPropsType) {
   return (
     <S.Button
-      width={props.width}
-      height={props.height}
-      fontSize={props.fontSize}
-      color={props.color}
-      background={props.background}
-      border={props.border}
-      borderRadius={props.borderRadius}
-      fontWeight={props.fontWeight}
-      hoverBackground={props.hoverBackground}
-      hoverBorder={props.hoverBorder}
-      hoverColor={props.hoverColor}
+      width={width}
+      height={height}
+      fontSize={fontSize}
+      color={color}
+      background={background}
+      border={border}
+      borderRadius={borderRadius}
+      fontWeight={fontWeight}
+      hoverBackground={hoverBackground}
+      hoverBorder={hoverBorder}
+      hoverColor={hoverColor}
+      {...rest}
     >
-      {props.children}
+      {children}
     </S.Button>
   )
 }

--- a/components/common/Button/index.tsx
+++ b/components/common/Button/index.tsx
@@ -1,7 +1,8 @@
 import { ButtonPropsType } from '@/types/components/ButtonPropsType'
+import { memo } from 'react'
 import * as S from './style'
 
-export default function Button({
+function Button({
   children,
   width,
   height,
@@ -35,3 +36,5 @@ export default function Button({
     </S.Button>
   )
 }
+
+export default memo(Button)

--- a/types/components/TextAreaProps.ts
+++ b/types/components/TextAreaProps.ts
@@ -1,12 +1,10 @@
-import { ChangeEvent } from 'react'
+import { ChangeEvent, TextareaHTMLAttributes } from 'react'
 
-export interface TextareaPropsType {
-  value: string
-  onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void
+export interface TextareaPropsType
+  extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   height: string
   borderColor?: string
   placeholder?: string
   fontSize?: string
   margin?: string
-  name?: string
 }


### PR DESCRIPTION
## 💡 개요
extends 문법을 써서 타입상속을 받았지만 나머지 연산자 추가가 안 돼있어 적용이 되지 않았습니다.
## 📃 작업내용
나머지 연산자를 props에 추가하여 onClick 등이 작동되게 하였습니다.

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
