### PR TITLE
🔀 예약 모달 닫을 시 예약 상태를 지우는 코드 개선

### DIFF
--- a/hooks/useDeleteReservationStatus.tsx
+++ b/hooks/useDeleteReservationStatus.tsx
@@ -1,0 +1,27 @@
+import {
+  ModalPage,
+  Place,
+  ReasonText,
+  ShowMembers,
+  TeamMembers,
+} from '@/atoms/atom'
+import { UserItemType } from '@/types/UserItemType'
+import { useSetRecoilState } from 'recoil'
+
+export default function useDeleteReservationStatus() {
+  const setTeamMembers = useSetRecoilState<string[]>(TeamMembers)
+  const setShowMembers = useSetRecoilState<UserItemType[]>(ShowMembers)
+  const setReason = useSetRecoilState<string>(ReasonText)
+  const setModalPage = useSetRecoilState(ModalPage)
+  const setPlace = useSetRecoilState(Place)
+
+  const delReserveStatus = () => {
+    setTeamMembers([])
+    setShowMembers([])
+    setReason('')
+    setModalPage(1)
+    setPlace({ floor: '', period: '' })
+  }
+
+  return { delReserveStatus }
+}

--- a/modals/ReservationModal/Page/Completed/index.tsx
+++ b/modals/ReservationModal/Page/Completed/index.tsx
@@ -2,9 +2,11 @@ import * as S from './style'
 import * as SVG from '@/assets/svg'
 import Button from '@/components/common/Button'
 import useModal from '@/hooks/useModal'
+import useDeleteReservationStatus from '@/hooks/useDeleteReservationStatus'
 
 export default function Completed() {
   const { closeModal } = useModal()
+  const { delReserveStatus } = useDeleteReservationStatus()
 
   return (
     <S.CompletedContainer>
@@ -22,7 +24,10 @@ export default function Completed() {
           fontWeight='500'
           border='none'
           borderRadius='8px'
-          onClick={closeModal}
+          onClick={() => {
+            closeModal()
+            delReserveStatus()
+          }}
         >
           확인
         </Button>

--- a/modals/ReservationModal/index.tsx
+++ b/modals/ReservationModal/index.tsx
@@ -1,22 +1,23 @@
 import Portal from '@/components/Portal'
-import { useRecoilValue, useSetRecoilState } from 'recoil'
+import { useRecoilValue } from 'recoil'
 import * as S from './style'
-import { ModalPage, ReasonText, TeamMembers } from '@/atoms/atom'
+import { ModalPage } from '@/atoms/atom'
 import Reason from './Page/Reason'
 import MemberSelect from './Page/MemberSelect'
 import Completed from './Page/Completed'
 import PlaceSelect from './Page/PlaceSelect'
 import useModal from '@/hooks/useModal'
+import useDeleteReservationStatus from '@/hooks/useDeleteReservationStatus'
 
 function ReservationModal() {
   const { closeModal } = useModal()
-  const setTeamMembers = useSetRecoilState<string[]>(TeamMembers)
-  const setReason = useSetRecoilState<string>(ReasonText)
-  const page = useRecoilValue(ModalPage)
+  const { delReserveStatus } = useDeleteReservationStatus()
+
+  const page = useRecoilValue<number>(ModalPage)
+
   const onClose = () => {
     closeModal()
-    setTeamMembers([])
-    setReason('')
+    delReserveStatus()
   }
 
   return (


### PR DESCRIPTION
## 💡 개요
여러 값을 일일이 `useSetRecoilState`들을 선언해 초기화 했었습니다.
## 📃 작업내용
custom hook을 만들어 예약 상태들을 편리하게 초기화 할 수 있게 했습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
