### PR TITLE
🔀 예약 상세조회, 전체 삭제 버튼 추가

### DIFF
--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -27,7 +27,7 @@ function Header() {
 
   useEffect(() => {
     ;(async () => await fetch())()
-  }, [])
+  }, [fetch])
 
   return (
     <S.HeaderContainer>

--- a/components/ReservationPage/index.tsx
+++ b/components/ReservationPage/index.tsx
@@ -8,11 +8,26 @@ import ReservationTableItem from './ReservationTableItem'
 import * as S from './style'
 import useModal from '@/hooks/useModal'
 import PlaceSelect from '@/modals/PlaceSelect'
+import Button from '../common/Button'
+import { GetRoleTypes } from '@/types/components/GetRoleTypes'
 
 function ReservationPage() {
   const reservationPlace = useRecoilValue(ReservationPlace)
   const { fetch, data } = useFetch<ReservationDataType[]>({
     url: `/homebase?period=${reservationPlace.period}&floor=${reservationPlace.floor}`,
+    method: 'get',
+  })
+
+  const today: Date = new Date()
+
+  const { fetch: deleteTable } = useFetch({
+    url: '/reservation/kill-all',
+    method: 'delete',
+    successMessage: '예약 테이블을 모두 삭제했습니다.',
+  })
+
+  const { fetch: fetchRole, data: roleDate } = useFetch<GetRoleTypes>({
+    url: '/user/my-role',
     method: 'get',
   })
 
@@ -25,6 +40,10 @@ function ReservationPage() {
   }, [fetch])
 
   useEffect(() => {
+    ;(async () => await fetchRole())()
+  }, [fetchRole])
+
+  useEffect(() => {
     setArr([1, 2, 3, 4, 5])
     setArr((prev: any) =>
       prev.map(
@@ -33,13 +52,55 @@ function ReservationPage() {
     )
   }, [data])
 
-  useEffect(() => {
-    openModal(<PlaceSelect />)
-  }, [])
-
   return (
     <PageContainer paddingTop='8vh' paddingBottom='5vh' background='#ffffff'>
-      <S.ReservationTitle>예약현황</S.ReservationTitle>
+      <S.ReservationTitleBox>
+        <S.ReservationTitle>
+          <h2>예약현황</h2>
+          <div>
+            {today.getFullYear()}.{today.getMonth().toString().padStart(2, '0')}
+            .{today.getDay().toString().padStart(2, '0')}
+          </div>
+          <div>
+            {reservationPlace.floor}층 &#12685; {reservationPlace.period}교시
+          </div>
+        </S.ReservationTitle>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <Button
+            width='3.8rem'
+            height='1.8rem'
+            border='1px solid #0066ff'
+            borderRadius='8px'
+            color='#0066ff'
+            fontSize='0.81rem'
+            fontWeight='500'
+            background='none'
+            hoverBackground='#0066ff'
+            hoverColor='#ffffff'
+            onClick={() => openModal(<PlaceSelect />)}
+          >
+            상세조회
+          </Button>
+          {roleDate?.role.includes('ROLE_ADMIN') && (
+            <Button
+              width='3.8rem'
+              height='1.8rem'
+              border='1px solid #FF002E'
+              borderRadius='8px'
+              color='#FF002E'
+              fontSize='0.81rem'
+              fontWeight='500'
+              background='none'
+              hoverBackground='#FF002E'
+              hoverColor='#ffffff'
+              style={{ marginLeft: '0.3rem' }}
+              onClick={async () => await deleteTable()}
+            >
+              전체삭제
+            </Button>
+          )}
+        </div>
+      </S.ReservationTitleBox>
       <S.ReservationTableContainer>
         {arr.slice(0, reservationPlace.floor === 3 ? 5 : 4).map((item, idx) => (
           <ReservationTableItem

--- a/components/ReservationPage/style.ts
+++ b/components/ReservationPage/style.ts
@@ -5,10 +5,36 @@ interface ShowCheckedBoxProps {
   disabled?: boolean
 }
 
-export const ReservationTitle = styled.h2`
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: #3c3c43;
+export const ReservationTitleBox = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`
+
+export const ReservationTitle = styled.div`
+  display: flex;
+  align-items: center;
+
+  h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #3c3c43;
+    margin-right: 0.7rem;
+  }
+
+  div {
+    background-color: #f5f5f5;
+    color: #9e9e9e;
+    font-size: 0.8rem;
+    width: 5.4rem;
+    height: 1.8rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 0.4rem;
+    border-radius: 8px;
+  }
 `
 
 export const ReservationTableContainer = styled.div`


### PR DESCRIPTION
## 💡 개요
사용자가 상세조회를 볼 방법이 필요했습니다.
관리자가 테이블을 전체 삭제할 수 있어야 했습니다.
## 📃 작업내용
버튼들을 추가하고 날짜, 층과 교시를 볼 수 있게 하였습니다.
![image](https://github.com/GSM-MSG/Hi-v2-FrontEnd/assets/105215297/ddef8dd1-3d72-4c36-9e46-7621334160f7)
