### PR TITLE
 🔀 recoil state와 useState로 테이블 조회하는 로직 수정

### DIFF
--- a/components/HomePage/Section1/index.tsx
+++ b/components/HomePage/Section1/index.tsx
@@ -1,13 +1,14 @@
-import { ArrowIcon, HiCharacter, ScrollMouseIcon } from '@/assets'
-import * as S from './style'
-import { Button } from '@/components'
-import Link from 'next/link'
 import TokenManager from '@/apis/TokenManager'
+import { ArrowIcon, HiCharacter, ScrollMouseIcon } from '@/assets'
+import { Button } from '@/components'
 import Image from 'next/image'
+import { useRouter } from 'next/router'
+import * as S from './style'
 import { toast } from 'react-toastify'
 
 function HomeSection1() {
   const tokenManager = new TokenManager()
+  const router = useRouter()
   return (
     <S.HomeSection1>
       <S.IntroductoryBox>
@@ -19,13 +20,18 @@ function HomeSection1() {
           <p>매번 불편했던 홈베이스 예약, HI로 쉽고 간편하게 예약해보세요!</p>
           <Button
             width='160px'
-            height='48px'
+            height='45px'
             color='#0066ff'
-            fontSize='18px'
+            fontSize='16.5px'
             fontWeight='600'
             lineHeight='21.48px'
             borderRadius='8px'
             border='none'
+            onClick={() =>
+              tokenManager.accessToken
+                ? router.push('/reservation')
+                : toast.info('로그인 후에 이용해 주세요')
+            }
           >
             예약하러 가기
             <ArrowIcon />

--- a/modals/PlaceSelect/index.tsx
+++ b/modals/PlaceSelect/index.tsx
@@ -1,28 +1,25 @@
-import { ReservationPlace, ReservationTables } from '@/atoms'
+import { get, homebaseQueryKeys, homebaseUrl } from '@/apis'
+import { XMark } from '@/assets'
+import { ReservationPlace } from '@/atoms'
 import { Button, Portal, Title, TitleBox } from '@/components'
 import { useModal } from '@/hooks'
-import { useState } from 'react'
-import { useRecoilState, useSetRecoilState } from 'recoil'
-import * as S from './style'
-import { XMark } from '@/assets'
-import { get, homebaseQueryKeys, homebaseUrl } from '@/apis'
+import { ReservationDataType } from '@/types'
 import { useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
-import { ReservationDataType } from '@/types'
+import { useEffect, useState } from 'react'
+import { useRecoilState } from 'recoil'
+import * as S from './style'
 
 function PlaceSelect() {
   const [reservationPlace, setReservationPlace] =
     useRecoilState(ReservationPlace)
-  const setReservationTables = useSetRecoilState(ReservationTables)
   const { closeModal } = useModal()
   const [showPlace] = useState<{ floors: number[]; periods: number[] }>({
     floors: [2, 3, 4],
     periods: [8, 9, 10, 11],
   })
-  const [floorClicked, setFloorClicked] = useState<number>(2)
-  const [periodClicked, setPeriodClicked] = useState<number>(8)
   const { floors, periods } = showPlace
-  const { data, refetch } = useQuery<AxiosResponse<ReservationDataType[]>>({
+  const { refetch } = useQuery<AxiosResponse<ReservationDataType[]>>({
     queryKey: homebaseQueryKeys.list(),
     queryFn: () =>
       get(
@@ -33,30 +30,24 @@ function PlaceSelect() {
       ),
   })
 
-  const onFloorClick = (floor: number) => {
-    setFloorClicked(floor)
+  const onFloorClick = (floor: number) =>
     setReservationPlace((prev) => {
       return {
         ...prev,
         floor,
       }
     })
-  }
-
-  const onPeriodClick = (period: number) => {
-    setPeriodClicked(period)
+  const onPeriodClick = (period: number) =>
     setReservationPlace((prev) => {
       return {
         ...prev,
         period,
       }
     })
-  }
 
-  const onApply = () => {
+  useEffect(() => {
     refetch()
-    closeModal()
-  }
+  }, [reservationPlace])
 
   return (
     <Portal onClose={closeModal}>
@@ -73,7 +64,7 @@ function PlaceSelect() {
             {floors.map((floor, idx) => (
               <S.FloorButton
                 key={idx}
-                clicked={floorClicked}
+                clicked={reservationPlace.floor}
                 current_value={floor}
                 onClick={() => onFloorClick(floor)}
               >
@@ -88,7 +79,7 @@ function PlaceSelect() {
             {periods.map((period, idx) => (
               <S.PeriodButton
                 key={idx}
-                clicked={periodClicked}
+                clicked={reservationPlace.period}
                 current_value={period}
                 onClick={() => onPeriodClick(period)}
               >
@@ -107,7 +98,7 @@ function PlaceSelect() {
             fontWeight='500'
             border='none'
             borderRadius='8px'
-            onClick={onApply}
+            onClick={closeModal}
           >
             확인
           </Button>

--- a/modals/PlaceSelect/style.ts
+++ b/modals/PlaceSelect/style.ts
@@ -62,7 +62,7 @@ export const PeriodButton = styled(FloorButton)`
 
 export const ButtonContainer = styled.div`
   position: absolute;
-  bottom: 10%;
+  bottom: 1.8125rem;
   width: 88%;
   display: flex;
   align-items: center;

--- a/modals/ReservationModal/Page/Reason/index.tsx
+++ b/modals/ReservationModal/Page/Reason/index.tsx
@@ -32,8 +32,8 @@ function Reason({
   isModify: boolean
   reservationId: string | undefined
 }) {
-  const setModalPage = useSetRecoilState(ModalPage)
   const reservationPlace = useRecoilValue(ReservationPlace)
+  const setModalPage = useSetRecoilState(ModalPage)
   const [reasonText, setReasonText] = useRecoilState(ReasonText)
   const [teamMembers, setTeamMembers] = useRecoilState(TeamMembers)
 

--- a/modals/ViewReservationModal/index.tsx
+++ b/modals/ViewReservationModal/index.tsx
@@ -1,17 +1,14 @@
 import { get, patch, reservationQueryKeys, reservationUrl } from '@/apis'
 import { TableCheckIcon, XMark } from '@/assets'
-import { ReservationPlace } from '@/atoms'
 import { Button, Portal, Title, TitleBox } from '@/components'
 import { useGetRole, useModal } from '@/hooks'
-import {
-  DeleteTableCheckModal,
-  LeaveReservationTableModal
-} from '@/modals'
+import { DeleteTableCheckModal, LeaveReservationTableModal } from '@/modals'
 import { ViewReservationData, ViewReservationDataTypes } from '@/types'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
 import { useRecoilValue } from 'recoil'
 import * as S from './style'
+import { ReservationPlace } from '@/atoms'
 
 export default function ViewReservationModal({
   reservationId,


### PR DESCRIPTION
## 💡 개요
recoil state를 refetch와 동일한 함수에 넣으면 state의 비동기 동작 때문에 원하는 조건의 테이블이 검색되지 않아
층, 교시를 선택하는 함수에 넣었는데 검색할 때 예약된 테이블이 그대로 보였습니다.
기본 state를 설정해놔서 모달을 킬 때마다 고정 되어있었습니다.
## 📃 작업내용
- 해당 모달의 기본 state를 recoil state값으로 변경 했습니다.
- recoil state가 변경 될 때마다 테이블을 조회하도록 했습니다.
