### PR TITLE
🔀 공지사항 추가, 수정한 후 처리 로직 수정

### DIFF
--- a/components/NoticePage/NoticeItemList/index.tsx
+++ b/components/NoticePage/NoticeItemList/index.tsx
@@ -8,7 +8,7 @@ import { AxiosResponse } from 'axios'
 import { get, noticeQueryKeys, noticeUrl } from '@/apis'
 
 export default function NoticeItemList() {
-  const { data } = useQuery<AxiosResponse<NoticeItemListType>>({
+  const { data } = useQuery<AxiosResponse<NoticeItemListType[]>>({
     queryKey: noticeQueryKeys.list(),
     queryFn: () => get(noticeUrl.notice()),
   })

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "next": "13.4.12",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-hook-form": "^7.45.4",
     "react-toastify": "^9.1.3",
     "recoil": "^0.7.7",
     "typescript": "5.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2144,11 +2144,6 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-hook-form@^7.45.4:
-  version "7.45.4"
-  resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.45.4.tgz"
-  integrity sha512-HGDV1JOOBPZj10LB3+OZgfDBTn+IeEsNOKiq/cxbQAIbKaiJUe/KV8DBUzsx0Gx/7IG/orWqRRm736JwOfUSWQ==
-
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"


### PR DESCRIPTION
## 💡 개요
공지사항을 추가하거나 수정한 다음 router.push를 하면 공지 리스트가 최신으로 보여지지 않았습니다.
## 📃 작업내용
- useEffect에 router.push를 onSuccess로 이동
- refetch를 onSuccess에 넣어 최신 공지사항 불러오기
