### PR TITLE
🔀 멤버 정보 검색 딜레이 줄이기

### DIFF
--- a/components/NoticePage/NoticeItemList/index.tsx
+++ b/components/NoticePage/NoticeItemList/index.tsx
@@ -1,11 +1,9 @@
-import { useGetRole } from '@/hooks'
+import { get, noticeQueryKeys, noticeUrl } from '@/apis'
 import { NoticeItemListType } from '@/types'
-import { useEffect } from 'react'
-import NoticeItem from '../NoticeItem'
-import * as S from './style'
 import { useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
-import { get, noticeQueryKeys, noticeUrl } from '@/apis'
+import NoticeItem from '../NoticeItem'
+import * as S from './style'
 
 export default function NoticeItemList() {
   const { data } = useQuery<AxiosResponse<NoticeItemListType[]>>({

--- a/components/NoticePage/NoticeWritePage/index.tsx
+++ b/components/NoticePage/NoticeWritePage/index.tsx
@@ -1,13 +1,12 @@
 import { noticeQueryKeys, noticeUrl, patch, post } from '@/apis'
 import { Button, Input, PageContainer, Textarea } from '@/components'
+import { NoticeItemListType, NoticeType } from '@/types'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { toast } from 'react-toastify'
 import * as S from './style'
-import { NoticeItemListType, NoticeType } from '@/types'
-import { get } from 'http'
 
 export default function NoticeWritePage() {
   const router = useRouter()

--- a/components/commons/Modal/Container.ts
+++ b/components/commons/Modal/Container.ts
@@ -19,7 +19,6 @@ export const CheckModalContainer = styled.div`
   p {
     color: ${({ theme }) => theme.color.Grayscale.gray06};
     font-size: 17px;
-    letter-spacing: -2px;
     margin-bottom: 29px;
 
     b {

--- a/modals/ReservationModal/Page/MemberSelect/index.tsx
+++ b/modals/ReservationModal/Page/MemberSelect/index.tsx
@@ -36,7 +36,7 @@ function MemberSelect({maxCapacity}: {maxCapacity: number}) {
     if (!member.trim()) return
     const delayFetch = setTimeout(() => {
       refetch()
-    }, 1000)
+    }, 500)
     return () => clearTimeout(delayFetch)
   }, [member, refetch])
 


### PR DESCRIPTION
## 💡 개요
멤버를 검색할 때 주는 딜레이 시간이 체감상 길었습니다.
## 📃 작업내용
딜레이 시간을 1s에서 0.5s으로 줄였습니다.

