### PR TITLE
🔀 헤더와 예약 페이지 반응형 적용

### DIFF
--- a/components/Header/style.ts
+++ b/components/Header/style.ts
@@ -53,10 +53,11 @@ export const MenuListBox = styled.ul<{ is_admin?: boolean }>`
   }
 `
 
-export const LoginBtn = styled.button`
+export const LoginBtn = styled.div`
+  width: 84px;
+  height: 36px;
   border: none;
   border-radius: 8px;
-  padding: 0.5rem 0.8rem 0.3rem 0.8rem;
   cursor: pointer;
   background: ${({ theme }) => theme.color.primary};
   color: ${({ theme }) => theme.color.white};
@@ -65,8 +66,15 @@ export const LoginBtn = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
 
-  @media screen and (max-width: 600px) {
-    font-size: 0.8rem;
+  @media screen and (max-width: 670px) {
+    width: 70px;
+    height: 30px;
+    ${({ theme }) => theme.typography.body2.semibold};
+  }
+
+  @media screen and (max-width: 450px) {
+    ${({ theme }) => theme.typography.caption.semibold};
   }
 `

--- a/components/ReservationPage/index.tsx
+++ b/components/ReservationPage/index.tsx
@@ -8,7 +8,11 @@ import {
 } from '@/apis'
 import { ReservationPlace } from '@/atoms'
 import { useGetRole, useModal } from '@/hooks'
-import { AllDeleteTableCheckModal, FloorLocationModal, PlaceSelect } from '@/modals'
+import {
+  AllDeleteTableCheckModal,
+  FloorLocationModal,
+  PlaceSelect,
+} from '@/modals'
 import { ReservationDataType } from '@/types'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
@@ -57,8 +61,8 @@ function ReservationPage() {
         </S.ReservationTitle>
         <S.ButtonContainer>
           <Button
-          width='80px'
-          height='36px'
+            width='80px'
+            height='36px'
             border='1px solid #0066ff'
             color='#0066ff'
             hoverBackground='#0066ff'
@@ -67,8 +71,8 @@ function ReservationPage() {
             상세조회
           </Button>
           <Button
-          width='98px'
-          height='36px'
+            width='98px'
+            height='36px'
             border='1px solid #0066ff'
             color='#0066ff'
             hoverBackground='#0066ff'
@@ -78,8 +82,8 @@ function ReservationPage() {
           </Button>
           {isAdmin && (
             <Button
-            width='80px'
-          height='36px'
+              width='80px'
+              height='36px'
               border='1px solid #FF002E'
               color='#FF002E'
               hoverBackground='#FF002E'

--- a/components/ReservationPage/style.ts
+++ b/components/ReservationPage/style.ts
@@ -15,21 +15,28 @@ export const ReservationTitle = styled.div`
     ${({ theme }) => theme.typography.h4.bold};
     line-height: 33.41px;
     color: ${({ theme }) => theme.color.Grayscale.gray09};
-    margin-right: 0.7rem;
+    margin-right: 11.2px;
   }
 
   div {
     background-color: ${({ theme }) => theme.color.Background.sub};
     color: ${({ theme }) => theme.color.Grayscale.gray06};
-    font-size: 0.8rem;
-    width: 5.4rem;
-    height: 1.8rem;
+    font-size: 12.8px;
+    width: 86.4px;
+    height: 28.8px;
     display: flex;
     align-items: center;
     justify-content: center;
     margin-right: 0.4rem;
     border-radius: 8px;
   }
+
+  @media screen and (max-width: 670px){
+    div {
+      display: none;
+    }
+  }
+
 `
 
 export const ReservationTableContainer = styled.div`
@@ -59,6 +66,14 @@ export const ButtonContainer = styled.div`
 
     &:hover {
       color: ${({theme}) => theme.color.white};
+    }
+  }
+
+  @media screen and (max-width: 450px) {
+    button {
+      &:nth-child(2) {
+        display: none;
+      }
     }
   }
 `


### PR DESCRIPTION
## 💡 개요
창을 줄일 때 로그아웃 버튼과 늘어난 버튼이 반응형에 적합하지 않았습니다.
## 📃 작업내용
<img width="481" alt="image" src="https://github.com/GSM-MSG/Hi-v2-FrontEnd/assets/105215297/76db92d2-1714-44df-89ad-f4aa4d415624">
