### PR TITLE
🔀 accessToken null 해결

### DIFF
--- a/apis/TokenManager.ts
+++ b/apis/TokenManager.ts
@@ -81,7 +81,8 @@ class TokenManager {
       )
 
       this.setTokens(data)
-      Router.reload()
+      // Router.reload()
+      Router.push(window.location.href)
       return true
     } catch (error) {
       this.removeTokens()

--- a/apis/TokenManager.ts
+++ b/apis/TokenManager.ts
@@ -81,7 +81,6 @@ class TokenManager {
       )
 
       this.setTokens(data)
-      // Router.reload()
       Router.push(window.location.href)
       return true
     } catch (error) {

--- a/apis/TokenManager.ts
+++ b/apis/TokenManager.ts
@@ -81,7 +81,7 @@ class TokenManager {
       )
 
       this.setTokens(data)
-
+      Router.reload()
       return true
     } catch (error) {
       this.removeTokens()

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -46,7 +46,6 @@ export default function App({ Component, pageProps }: AppProps) {
         defaultOptions: {
           queries: {
             retry: false,
-            refetchOnWindowFocus: false,
           },
         },
       })


### PR DESCRIPTION
## 💡 개요
localStorage에서 accessToken을 의도적으로 삭제할 경우 TokenManager의 accessToken의 값이 null 이었습니다.
## 📃 작업내용
- 재발급 함수가 실행되면 현재 페이지로 이동시키는 이벤트 발생시키기
