### PR TITLE
🔀 토큰 변질 오류 처리

### DIFF
--- a/apis/TokenManager.ts
+++ b/apis/TokenManager.ts
@@ -75,7 +75,7 @@ class TokenManager {
           baseURL: BASE_URL,
           withCredentials: true,
           headers: {
-            RefreshToken: this.refreshToken && `Bearer ${refreshToken}`,
+            RefreshToken: this.refreshToken && `Bearer ${encodeURI(refreshToken || '')}`,
           },
         }
       )

--- a/apis/instance.ts
+++ b/apis/instance.ts
@@ -21,11 +21,7 @@ API.interceptors.request.use(async (config: InternalAxiosRequestConfig) => {
     tokenManager.refreshToken
   )
 
-  if (!accessTokenIsValid && refreshTokenIsValid) {
-    await tokenManager.reissueToken({ refreshToken: tokenManager.refreshToken })
-    tokenManager.initToken()
-  } else if (!accessTokenIsValid && !refreshTokenIsValid)
-    tokenManager.removeTokens()
+  if (!accessTokenIsValid && !refreshTokenIsValid) tokenManager.removeTokens()
 
   config.headers['Authorization'] = tokenManager.accessToken
     ? `Bearer ${encodeURI(tokenManager.accessToken)}`
@@ -45,11 +41,12 @@ API.interceptors.response.use(
           refreshToken: tokenManager.refreshToken,
         })
         tokenManager.initToken()
-        error.config.headers[
-          'Authorization'
-        ] = `Bearer ${tokenManager.accessToken}`
-      } catch (err) {
-        console.log(err)
+        error.config.headers['Authorization'] = tokenManager.accessToken
+      ? `Bearer ${encodeURI(tokenManager.accessToken)}`
+      : undefined
+      return API(error.config)
+      } catch(err) {
+        console.log(error)
       }
     }
   }


### PR DESCRIPTION
## 💡 개요
토큰을 의도적으로 변질시킬 때 재발급을 시키지 못했습니다.
## 📃 작업내용
- axios의 interceptors.response.use 를 사용해 401 오류 처리를 했습니다.
