### PR TITLE
🔀 공지사항 상세 id undefined 요청 해결

### DIFF
--- a/components/NoticePage/NoticeDetail/index.tsx
+++ b/components/NoticePage/NoticeDetail/index.tsx
@@ -13,14 +13,13 @@ import { useEffect, useState } from 'react'
 export default function NoticeDetailPage() {
   const router = useRouter()
   const [isMounted, setIsMounted] = useState<boolean>(false)
-  const id = String(router.query.id)
+  const { id } = router.query
 
   const { data } = useQuery<AxiosResponse<NoticeDetailType>>({
-    queryKey: noticeQueryKeys.detail(id),
-    queryFn: () => get(noticeUrl.requestId(id)),
-    enabled: !!id,
+    queryKey: noticeQueryKeys.detail(id + ''),
+    queryFn: () => get(noticeUrl.requestId(id + '')),
+    enabled: typeof id === 'string',
   })
-
   const { title, content, createdAt, user } = data?.data || {}
   const onModify = () => {
     if (data) {


### PR DESCRIPTION
## 💡 개요
공지사항 상세에서 id가 undefined일 때도 요청을 보내 400이 발생했습니다.
## 📃 작업내용
- enabled속성에 타입 가드를 사용해 id가 string일 때만 요청