### PR TITLE
🔀 예약 조회 모달 liine-height 조절

### DIFF
--- a/components/ReservationPage/ReservationTableItem/index.tsx
+++ b/components/ReservationPage/ReservationTableItem/index.tsx
@@ -97,7 +97,7 @@ export default function ReservationTableItem({
           <span>예약 가능 합니다.</span>
         )}
         <S.ShowDetailName style={{ color: theme.color.Grayscale.gray05 }}>
-          {isShowDetail && item.users.map((user) => user.name).join(', ')}
+          {isShowDetail && item.users?.map((user) => user.name).join(', ')}
         </S.ShowDetailName>
       </S.TableInfoBox>
       <S.ReservationButtonContainer>

--- a/modals/ViewReservationModal/ViewReservationData/style.ts
+++ b/modals/ViewReservationModal/ViewReservationData/style.ts
@@ -16,16 +16,16 @@ export const ViewReservationDataColumn = styled.div<{ column: number }>`
   display: flex;
   align-items: flex-start;
   ${({ theme }) => theme.typography.body2.semibold};
-  gap: ${({ column }) =>
-    column > 1 ? '32px' : column === 0 ? '48px' : '20px'};
+  gap: 20px;
 
   span {
     color: ${({ theme }) => theme.color.Grayscale.gray05};
+    width: 66px;
   }
 
   p {
-    width: ${({ column }) => (column === 2 ? '196px' : '182px')};
     ${({ theme }) => theme.typography.body2.regular};
+    line-height: 15px;
     color: #0b041e;
 
     span {

--- a/modals/ViewReservationModal/index.tsx
+++ b/modals/ViewReservationModal/index.tsx
@@ -13,7 +13,7 @@ import {
   ViewReservationDataResponseTypes,
   ViewReservationDataTypes,
 } from '@/types'
-import { UseQueryResult, useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
 import LoadingViewReservation from './LoadingComponent'
 import ViewReservationData from './ViewReservationData'


### PR DESCRIPTION
## 💡 개요
예약 조회 모달에서 각 column의 위치가 맞지 않았습니다.
## 📃 작업내용
- line-height 조정
- 조건부 margin, gap 삭제
- span에 width 추가
<img width="468" alt="image" src="https://github.com/GSM-MSG/Hi-v2-FrontEnd/assets/105215297/7b91b495-7725-4b39-b7ff-aff3cd1c0d68">

