### PR TITLE
🔀 특정 시간에 맞춰서 기본 교시 변경

### DIFF
--- a/atoms/index.ts
+++ b/atoms/index.ts
@@ -10,11 +10,15 @@ const time9 = new Date()
 time9.setHours(17, 40)
 const time10 = new Date()
 time10.setHours(19, 30)
-const currentTime = new Date()
-const is7Period = new Date().getDay() === 1 && currentTime < time7
-const is8Period = currentTime < time8
-const is9Period = currentTime < time9
-const is10Period = currentTime < time10
+
+const currentPeriod = (): number => {
+  const currentTime = new Date()
+  if (new Date().getDay() === 1 && currentTime < time7) return 7
+  else if (currentTime < time8) return 8
+  else if (currentTime < time9) return 9
+  else if (currentTime < time10) return 10
+  else return 8
+}
 
 export const IsModal = atom<ReactNode>({ key: 'IsModal', default: null })
 
@@ -22,15 +26,7 @@ export const ReservationPlace = atom<{ floor: number; period: number }>({
   key: 'Place',
   default: {
     floor: 2,
-    period: is7Period
-      ? 7
-      : is8Period
-      ? 8
-      : is9Period
-      ? 9
-      : is10Period
-      ? 10
-      : 11,
+    period: currentPeriod(),
   },
 })
 

--- a/atoms/index.ts
+++ b/atoms/index.ts
@@ -2,11 +2,36 @@ import { UserItemType } from '@/types/components'
 import { ReactNode } from 'react'
 import { atom } from 'recoil'
 
+const time7 = new Date()
+time7.setHours(15, 30)
+const time8 = new Date()
+time8.setHours(16, 40)
+const time9 = new Date()
+time9.setHours(17, 40)
+const time10 = new Date()
+time10.setHours(19, 30)
+const currentTime = new Date()
+const is7Period = new Date().getDay() === 1 && currentTime < time7
+const is8Period = currentTime < time8
+const is9Period = currentTime < time9
+const is10Period = currentTime < time10
+
 export const IsModal = atom<ReactNode>({ key: 'IsModal', default: null })
 
 export const ReservationPlace = atom<{ floor: number; period: number }>({
   key: 'Place',
-  default: { floor: 2, period: new Date().getDay() === 1 ? 7 :  8 },
+  default: {
+    floor: 2,
+    period: is7Period
+      ? 7
+      : is8Period
+      ? 8
+      : is9Period
+      ? 9
+      : is10Period
+      ? 10
+      : 11,
+  },
 })
 
 export const ModalPage = atom<number>({ key: 'ModalPage', default: 1 })


### PR DESCRIPTION
## 💡 배경 및 개요
8교시가 기본으로 되어 있어서 8교시가 지나면 다른 교시를 선택해야하는 번거로움이 있었습니다.
## 📃 작업내용
- 각 교시마다 특정한 시간 설정
- 현재 시간이 그 시간보다 적다면 시간에 맞는 교시 설정

## 🙋‍♂️ 리뷰노트
date간의 크기 비교는 해봤지만 특정 시간까지 맞출 수 있는지 처음 알아서 유익했습니다.
선언한 변수가 많고 삼항 연산자가 많아 가독성이 좋지 않을 수 있다고 생각해 다음 코드를 대안으로 생각했습니다.
```js
const currentPeriod = (): number => {
  const currentTime = new Date()
  if (new Date().getDay() === 1 && currentTime < time7) return 7
  else if (currentTime < time8) return 8
  else if (currentTime < time9) return 9
  else if (currentTime < time10) return 10
  else return 11
}
```

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?