### PR TITLE
🔀 data 접근 줄이기

### DIFF
--- a/apis/instance.ts
+++ b/apis/instance.ts
@@ -35,7 +35,7 @@ API.interceptors.request.use(async (config: InternalAxiosRequestConfig) => {
 
 API.interceptors.response.use(
   (res) => {
-    return res
+    return res.data
   },
   async (error) => {
     const tokenManager = new TokenManager()

--- a/components/MyPage/index.tsx
+++ b/components/MyPage/index.tsx
@@ -1,19 +1,17 @@
-import { UserProfile } from '@/assets'
-import Image from 'next/image'
-import * as S from './style'
-import { useQuery } from '@tanstack/react-query'
-import { AxiosResponse } from 'axios'
 import { get, userQueryKeys, userUrl } from '@/apis'
-import ReservationItem from '../ReservationItem'
+import { UserProfile } from '@/assets'
 import { MyPageType } from '@/types'
+import { useQuery } from '@tanstack/react-query'
+import Image from 'next/image'
+import ReservationItem from '../ReservationItem'
+import * as S from './style'
 
 export default function MyPage() {
-  const { data } = useQuery<AxiosResponse<MyPageType>>({
+  const { data } = useQuery<MyPageType>({
     queryKey: userQueryKeys.my(),
     queryFn: () => get(userUrl.my()),
   })
-  const { useStatus, profileImageUrl, name, email, reservations } =
-    data?.data || {}
+  const { useStatus, profileImageUrl, name, email, reservations } = data || {}
   const buttonColor = useStatus === 'AVAILABLE' ? '#00A441' : '#C0C0C0'
 
   return (

--- a/components/NoticePage/NoticeDetail/index.tsx
+++ b/components/NoticePage/NoticeDetail/index.tsx
@@ -1,26 +1,24 @@
+import { get, noticeQueryKeys, noticeUrl } from '@/apis'
+import { BackArrowIcon } from '@/assets'
 import { Button, PageContainer } from '@/components'
 import { NoticeDetailType } from '@/types'
 import { dateToString } from '@/utils'
+import { useQuery } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import * as S from './style'
-import { BackArrowIcon } from '@/assets'
-import { useQuery } from '@tanstack/react-query'
-import { AxiosResponse } from 'axios'
-import { get, noticeQueryKeys, noticeUrl } from '@/apis'
-import { useEffect, useState } from 'react'
 
 export default function NoticeDetailPage() {
   const router = useRouter()
-  const [isMounted, setIsMounted] = useState<boolean>(false)
   const { id } = router.query
 
-  const { data } = useQuery<AxiosResponse<NoticeDetailType>>({
+  const { data } = useQuery<NoticeDetailType, AxiosError>({
     queryKey: noticeQueryKeys.detail(id + ''),
     queryFn: () => get(noticeUrl.requestId(id + '')),
     enabled: typeof id === 'string',
   })
-  const { title, content, createdAt, user } = data?.data || {}
+  const { title, content, createdAt, user } = data || {}
   const onModify = () => {
     if (data) {
       router.push(
@@ -32,10 +30,6 @@ export default function NoticeDetailPage() {
       )
     }
   }
-
-  useEffect(() => {
-    setIsMounted(true)
-  }, [])
 
   return (
     <PageContainer
@@ -69,8 +63,8 @@ export default function NoticeDetailPage() {
             )}
           </S.DetailTitleContainer>
           <S.DetailInfo>
-            <div>작성일 : {isMounted && dateToString(createdAt ?? '')}</div>
-            <div>작성자 : {isMounted && user?.name}</div>
+            <div>작성일 : {dateToString(createdAt ?? '')}</div>
+            <div>작성자 : {user?.name}</div>
           </S.DetailInfo>
           <S.DetailContent>{content}</S.DetailContent>
         </S.DetailWrapper>

--- a/components/NoticePage/NoticeItemList/index.tsx
+++ b/components/NoticePage/NoticeItemList/index.tsx
@@ -6,16 +6,14 @@ import NoticeItem from '../NoticeItem'
 import * as S from './style'
 
 export default function NoticeItemList() {
-  const { data } = useQuery<AxiosResponse<NoticeItemType[]>>({
+  const { data: noticeList } = useQuery<NoticeItemType[]>({
     queryKey: noticeQueryKeys.list(),
     queryFn: () => get(noticeUrl.notice()),
   })
 
   return (
     <S.NoticeItemListContainer>
-      {data &&
-        Array.isArray(data.data) &&
-        data.data.map(({ index, noticeId, title, createdAt, user }, idx) => (
+      {noticeList?.map(({ index, noticeId, title, createdAt, user }, idx) => (
           <NoticeItem
             key={idx}
             index={index}

--- a/components/ReservationPage/ReservationTableItem/index.tsx
+++ b/components/ReservationPage/ReservationTableItem/index.tsx
@@ -10,7 +10,7 @@ import {
 import { theme } from '@/styles'
 import { MyPageType, ReservationDataType } from '@/types'
 import { useQuery } from '@tanstack/react-query'
-import { AxiosResponse } from 'axios'
+import { AxiosError } from 'axios'
 import { useState } from 'react'
 import { toast } from 'react-toastify'
 import { useSetRecoilState } from 'recoil'
@@ -26,11 +26,11 @@ export default function ReservationTableItem({
   const setReasonText = useSetRecoilState(ReasonText)
   const [isShowDetail, setIsShowDetail] = useState<boolean>(false)
   const { openModal } = useModal()
-  const { data } = useQuery<AxiosResponse<MyPageType>>({
+  const { data } = useQuery<MyPageType, AxiosError>({
     queryKey: userQueryKeys.my(),
     queryFn: () => get(userUrl.my()),
   })
-  const { useStatus } = data?.data || {}
+  const { useStatus } = data || {}
   const { isTeacher, userId } = useGetRole()
 
   const onModify = () => {

--- a/components/ReservationPage/index.tsx
+++ b/components/ReservationPage/index.tsx
@@ -15,20 +15,18 @@ import {
 } from '@/modals'
 import { ReservationDataType } from '@/types'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { AxiosResponse } from 'axios'
+import { AxiosError } from 'axios'
+import { useState } from 'react'
 import { toast } from 'react-toastify'
 import { useRecoilValue } from 'recoil'
 import { Button, PageContainer } from '../commons'
 import ReservationTableItem from './ReservationTableItem'
 import * as S from './style'
-import { useState } from 'react'
 
 export default function ReservationPage() {
   const reservationPlace = useRecoilValue(ReservationPlace)
   const { closeModal } = useModal()
-  const { data, isLoading, refetch } = useQuery<
-    AxiosResponse<ReservationDataType[]>
-  >({
+  const { data: reservationList, isLoading, refetch } = useQuery<ReservationDataType[], AxiosError>({
     queryKey: homebaseQueryKeys.list(),
     queryFn: () =>
       get(
@@ -108,7 +106,7 @@ export default function ReservationPage() {
         {isLoading ? (
           <S.LoadingText>예약 현황을 가져오는 중입니다..</S.LoadingText>
         ) : (
-          data?.data.map((item, idx) => (
+          reservationList?.map((item, idx) => (
             <ReservationTableItem key={idx} item={item} />
           ))
         )}

--- a/components/UserPage/index.tsx
+++ b/components/UserPage/index.tsx
@@ -3,7 +3,7 @@ import { SearchIcon } from '@/assets'
 import { useGetRole } from '@/hooks'
 import { UserItemListType } from '@/types'
 import { useQuery } from '@tanstack/react-query'
-import { AxiosResponse } from 'axios'
+import { AxiosError } from 'axios'
 import { useRouter } from 'next/router'
 import { FormEvent, useEffect, useState } from 'react'
 import { Input, PageContainer } from '../commons'
@@ -14,7 +14,7 @@ export default function UserPage() {
   const { isStudent } = useGetRole()
   const [user, setUser] = useState<string>('')
   const router = useRouter()
-  const { data, refetch } = useQuery<AxiosResponse<UserItemListType>>({
+  const { data: userList, refetch } = useQuery<UserItemListType, AxiosError>({
     queryKey: userQueryKeys.searchUser(),
     queryFn: () => get(userUrl.searchUser(user)),
   })
@@ -51,7 +51,7 @@ export default function UserPage() {
         </S.InputWrapper>
       </S.UserTitleContainer>
       <S.UserItemListContainer>
-        {data?.data.map(
+        {userList?.map(
           (
             {
               userId,

--- a/hooks/useGetRole.tsx
+++ b/hooks/useGetRole.tsx
@@ -2,22 +2,23 @@ import { get, userQueryKeys, userUrl } from '@/apis'
 import TokenManager from '@/apis/TokenManager'
 import { GetRoleType, RoleTypes, useGetRoleReturnType } from '@/types'
 import { useQuery } from '@tanstack/react-query'
-import { AxiosResponse } from 'axios'
+import { AxiosError } from 'axios'
 
 export default function useGetRole(): useGetRoleReturnType {
   const tokenManager = new TokenManager()
-  const { data } = useQuery<AxiosResponse<GetRoleType>>({
+  const { data } = useQuery<GetRoleType, AxiosError>({
     queryKey: userQueryKeys.myRole(),
     queryFn: () => get(userUrl.myRole()),
     enabled: !!tokenManager.accessToken,
   })
+  const { role, userId } = data || {}
 
-  const hasRole = (role: RoleTypes) => role === data?.data.role
+  const hasRole = (roleType: RoleTypes) => roleType === role
 
   return {
     isAdmin: hasRole('ROLE_ADMIN'),
     isTeacher: hasRole('ROLE_TEACHER'),
     isStudent: hasRole('ROLE_STUDENT'),
-    userId: data?.data.userId,
+    userId,
   }
 }

--- a/hooks/usePostLogin.tsx
+++ b/hooks/usePostLogin.tsx
@@ -2,7 +2,7 @@ import { authQueryKeys, authUrl, post } from '@/apis'
 import TokenManager from '@/apis/TokenManager'
 import { TokensType } from '@/types'
 import { useMutation } from '@tanstack/react-query'
-import { AxiosResponse } from 'axios'
+import { AxiosError } from 'axios'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import { toast } from 'react-toastify'
@@ -12,8 +12,8 @@ export default function usePostLogin() {
   const gauthCode = router.query.code?.toString()
 
   const { mutate } = useMutation<
-    AxiosResponse<TokensType>,
-    Error,
+    TokensType,
+    AxiosError,
     { code: string }
   >({
     mutationKey: authQueryKeys.login(),
@@ -21,7 +21,7 @@ export default function usePostLogin() {
     onSuccess: (data) => {
       if (typeof window !== 'undefined') {
         const tokenManager = new TokenManager()
-        tokenManager.setTokens(data?.data)
+        tokenManager.setTokens(data)
       }
       router.replace('')
       toast.success('로그인 되었습니다.')

--- a/modals/ReservationModal/Page/MemberSelect/index.tsx
+++ b/modals/ReservationModal/Page/MemberSelect/index.tsx
@@ -27,7 +27,7 @@ export default function MemberSelect({ maxCapacity }: { maxCapacity: number }) {
   const { closeModal } = useModal()
   const { delReserveStatus } = useDeleteReservationStatus()
 
-  const { data, refetch, isLoading } = useQuery<AxiosResponse<UserItemType[]>>({
+  const { data: memberList, refetch, isLoading } = useQuery<UserItemType[]>({
     queryKey: userQueryKeys.searchStudent(),
     queryFn: () => get(userUrl.searchStudent(member)),
   })
@@ -136,14 +136,13 @@ export default function MemberSelect({ maxCapacity }: { maxCapacity: number }) {
         <S.LoadingMemberListBox>
           <span>학생정보를 찾는 중입니다.</span>
         </S.LoadingMemberListBox>
-      ) : data?.data.length === 0 ? (
+      ) : memberList?.length === 0 ? (
         <S.LoadingMemberListBox>
           <span>학생정보를 찾을 수 없습니다.</span>
         </S.LoadingMemberListBox>
       ) : (
         <S.MemberListBox>
-          {data?.data
-            .sort((a, b) => {
+          {memberList?.sort((a, b) => {
               const aStudentNum = parseInt(
                 `${a.grade}${a.classNum}${
                   a.number && a.number.toString().padStart(2, '0')


### PR DESCRIPTION
## 💡 배경 및 개요
현재 데이터가 반환될 때 response 자체만 반환하기에 data?.data로 접근해야 했습니다.

## 📃 작업내용
- intereceptors.response.use에서 data까지 반환
- data를 사용하는 모든 페이지에서 접근 수 감소
- AxiosResponse 타입 없애기

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸
이번 pr과 관련은 없지만 ViewReservationModal에서 리스트 재요청을 
`refetch`에서 `queryClient.invalidateQueries({ queryKey: homebaseQueryKeys.list() })`로 변경했습니다.